### PR TITLE
Enhance tests and refactor controller for improved coverage

### DIFF
--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Validate coverage
         run: |
           coverage=$(echo "${{ steps.coverage.outputs.percentage }}" | tr -d '%')
-          threshold=15
+          threshold=50
           if (( $(echo "$coverage < $threshold" | bc -l) )); then
             echo "Test coverage (${coverage}%) is below ${threshold}%"
             exit 1

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/edigar/socialnets-api/internal/config"
+	"github.com/edigar/socialnets-api/internal/database"
 	"github.com/edigar/socialnets-api/internal/router"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -15,7 +17,14 @@ import (
 
 func main() {
 	config.Load()
-	r := router.Generate()
+
+	db, err := database.Connect()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	r := router.Generate(db)
 
 	server := &http.Server{Addr: fmt.Sprintf(":%d", config.Port), Handler: r}
 	fmt.Printf("SocialNets API is running on port %d...\n", config.Port)

--- a/internal/authentication/token_test.go
+++ b/internal/authentication/token_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestCreateToken(t *testing.T) {
@@ -104,4 +105,67 @@ func TestExtractUserIdInvalidToken(t *testing.T) {
 	if err == nil {
 		t.Errorf("ExtractUserId should return an error for an invalid token")
 	}
+}
+
+func TestTokenValidateRejectsNonHMACSigningMethod(t *testing.T) {
+	userId := "eedf21bf-dde8-4c85-b50b-89a1cba87c2e"
+	claims := jwt.MapClaims{
+		"authorized": true,
+		"exp":        time.Now().Add(time.Hour).Unix(),
+		"userId":     userId,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("Signing a none-method token should not fail: %v", err)
+	}
+
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer "+tokenString)
+
+	if err = TokenValidate(request); err == nil {
+		t.Errorf("TokenValidate should reject a token signed with a non-HMAC method (algorithm confusion)")
+	}
+	if _, err = ExtractUserId(request); err == nil {
+		t.Errorf("ExtractUserId should reject a token signed with a non-HMAC method (algorithm confusion)")
+	}
+}
+
+func TestTokenValidateRejectsExpiredToken(t *testing.T) {
+	claims := jwt.MapClaims{
+		"authorized": true,
+		"exp":        time.Now().Add(-time.Hour).Unix(),
+		"userId":     "eedf21bf-dde8-4c85-b50b-89a1cba87c2e",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(config.SecretKey)
+	if err != nil {
+		t.Fatalf("Signing the token should not fail: %v", err)
+	}
+
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer "+tokenString)
+
+	if err = TokenValidate(request); err == nil {
+		t.Errorf("TokenValidate should reject an expired token")
+	}
+}
+
+func TestTokenValidateRejectsMissingOrMalformedHeader(t *testing.T) {
+	t.Run("missing Authorization header", func(t *testing.T) {
+		request, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+		if err := TokenValidate(request); err == nil {
+			t.Errorf("TokenValidate should return an error when the Authorization header is missing")
+		}
+	})
+
+	t.Run("Authorization header without bearer token", func(t *testing.T) {
+		request, _ := http.NewRequest(http.MethodGet, "/", nil)
+		request.Header.Set("Authorization", "Bearer")
+
+		if err := TokenValidate(request); err == nil {
+			t.Errorf("TokenValidate should return an error when the Authorization header has no bearer token")
+		}
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	t.Run("Should use API_PORT when it is a valid number", func(t *testing.T) {
+		t.Setenv("ENVIRONMENT", "PROD")
+		t.Setenv("API_PORT", "9090")
+
+		Load()
+
+		if Port != 9090 {
+			t.Errorf("Load should set Port to 9090, got %d", Port)
+		}
+	})
+
+	t.Run("Should fall back to 8000 when API_PORT is invalid", func(t *testing.T) {
+		t.Setenv("ENVIRONMENT", "PROD")
+		t.Setenv("API_PORT", "not-a-number")
+
+		Load()
+
+		if Port != 8000 {
+			t.Errorf("Load should fall back to Port 8000, got %d", Port)
+		}
+	})
+
+	t.Run("Should build the DB connection string and load the secret key", func(t *testing.T) {
+		t.Setenv("ENVIRONMENT", "PROD")
+		t.Setenv("DB_USER", "user")
+		t.Setenv("DB_NAME", "socialnets")
+		t.Setenv("DB_PASSWORD", "secret")
+		t.Setenv("DB_HOST", "localhost")
+		t.Setenv("SECRET_KEY", "my-secret")
+
+		Load()
+
+		expected := "user=user dbname=socialnets password=secret host=localhost sslmode=disable"
+		if DbStringConnection != expected {
+			t.Errorf("Load should build the connection string.\n expected: %q\n got:      %q", expected, DbStringConnection)
+		}
+		if string(SecretKey) != "my-secret" {
+			t.Errorf("Load should set SecretKey to %q, got %q", "my-secret", string(SecretKey))
+		}
+	})
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,49 @@
+package controller
+
+import (
+	"github.com/edigar/socialnets-api/internal/dto"
+	"github.com/edigar/socialnets-api/internal/entity"
+)
+
+// UserUseCase is the set of user operations the controllers depend on.
+type UserUseCase interface {
+	Login(email string, password string) (string, error)
+	Register(user *entity.User) error
+	GetById(id string) (entity.User, error)
+	GetByNameOrNick(nameOrNick string) ([]entity.User, error)
+	Update(userId string, user entity.User) error
+	Delete(userId string) error
+	Follow(userId string, follower string) error
+	Unfollow(userId string, follower string) error
+	GetFollowers(userId string) ([]entity.User, error)
+	GetFollowing(userId string) ([]entity.User, error)
+	UpdatePassword(userId string, password dto.Password) error
+}
+
+// PostUseCase is the set of post operations the controllers depend on.
+type PostUseCase interface {
+	CreatePost(post *entity.Post) error
+	GetByUser(userId string) ([]entity.Post, error)
+	GetById(postId uint64) (entity.Post, error)
+	Update(authorId string, postId uint64, post entity.Post) error
+	Delete(postId uint64, authorId string) error
+	GetUserPosts(userId string) ([]entity.Post, error)
+	LikePost(postId uint64) error
+	UnLikePost(postId uint64) error
+}
+
+type UserController struct {
+	userUseCase UserUseCase
+}
+
+func NewUserController(userUseCase UserUseCase) *UserController {
+	return &UserController{userUseCase: userUseCase}
+}
+
+type PostController struct {
+	postUseCase PostUseCase
+}
+
+func NewPostController(postUseCase PostUseCase) *PostController {
+	return &PostController{postUseCase: postUseCase}
+}

--- a/internal/controller/health_controller_test.go
+++ b/internal/controller/health_controller_test.go
@@ -1,0 +1,25 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthCheck(t *testing.T) {
+	t.Run("Should return 200 with an ok status", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		HealthCheck(rec, newRequest(http.MethodGet, ""))
+
+		assertStatus(t, rec.Code, http.StatusOK)
+
+		var decoded map[string]string
+		if err := json.NewDecoder(rec.Body).Decode(&decoded); err != nil {
+			t.Fatalf("response should be valid JSON: %v", err)
+		}
+		if decoded["status"] != "ok" {
+			t.Errorf("HealthCheck should return status ok. Got: %v", decoded)
+		}
+	})
+}

--- a/internal/controller/login_controller.go
+++ b/internal/controller/login_controller.go
@@ -4,18 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/edigar/socialnets-api/internal/authentication"
-	"github.com/edigar/socialnets-api/internal/database"
 	"github.com/edigar/socialnets-api/internal/dto"
 	"github.com/edigar/socialnets-api/internal/entity"
-	"github.com/edigar/socialnets-api/internal/repository"
 	"github.com/edigar/socialnets-api/internal/response"
-	"github.com/edigar/socialnets-api/internal/usecase"
 	"golang.org/x/crypto/bcrypt"
 	"io"
 	"net/http"
 )
 
-func Login(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) Login(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		response.Error(w, http.StatusUnprocessableEntity, err)
@@ -25,17 +22,10 @@ func Login(w http.ResponseWriter, r *http.Request) {
 	var user entity.User
 	if err = json.Unmarshal(body, &user); err != nil {
 		response.Error(w, http.StatusBadRequest, err)
-	}
-
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
 		return
 	}
-	defer db.Close()
 
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	userId, err := userUseCase.Login(user.Email, user.Password)
+	userId, err := c.userUseCase.Login(user.Email, user.Password)
 	if err != nil {
 		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) || errors.Is(err, bcrypt.ErrHashTooShort) || errors.Is(err, bcrypt.ErrPasswordTooLong) {
 			response.Error(w, http.StatusUnauthorized, err)

--- a/internal/controller/post_controller.go
+++ b/internal/controller/post_controller.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/edigar/socialnets-api/internal/authentication"
-	"github.com/edigar/socialnets-api/internal/database"
 	"github.com/edigar/socialnets-api/internal/entity"
 	"github.com/edigar/socialnets-api/internal/error_type"
-	"github.com/edigar/socialnets-api/internal/repository"
 	"github.com/edigar/socialnets-api/internal/response"
 	"github.com/edigar/socialnets-api/internal/usecase"
 	"github.com/gorilla/mux"
@@ -17,7 +15,7 @@ import (
 	"strconv"
 )
 
-func PostPost(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) PostPost(w http.ResponseWriter, r *http.Request) {
 	userId, err := authentication.ExtractUserId(r)
 	if err != nil {
 		response.Error(w, http.StatusUnauthorized, err)
@@ -36,15 +34,7 @@ func PostPost(w http.ResponseWriter, r *http.Request) {
 
 	post.AuthorId = userId
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	if err = postUseCase.CreatePost(&post); err != nil {
+	if err = c.postUseCase.CreatePost(&post); err != nil {
 		var epv *errorType.ErrorPostValidation
 		if errors.As(err, &epv) {
 			response.Error(w, http.StatusBadRequest, epv.Err)
@@ -58,21 +48,14 @@ func PostPost(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusCreated, post)
 }
 
-func GetPosts(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) GetPosts(w http.ResponseWriter, r *http.Request) {
 	userId, err := authentication.ExtractUserId(r)
 	if err != nil {
 		response.Error(w, http.StatusUnauthorized, err)
 		return
 	}
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	posts, err := postUseCase.GetByUser(userId)
+	posts, err := c.postUseCase.GetByUser(userId)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
@@ -81,22 +64,15 @@ func GetPosts(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusOK, posts)
 }
 
-func GetPost(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) GetPost(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	postId, err := strconv.ParseUint(params["postId"], 10, 64)
 	if err != nil {
 		response.Error(w, http.StatusBadRequest, err)
 		return
 	}
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	post, err := postUseCase.GetById(postId)
+	post, err := c.postUseCase.GetById(postId)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
@@ -105,7 +81,7 @@ func GetPost(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusOK, post)
 }
 
-func UpdatePost(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) UpdatePost(w http.ResponseWriter, r *http.Request) {
 	userId, err := authentication.ExtractUserId(r)
 	if err != nil {
 		response.Error(w, http.StatusUnauthorized, err)
@@ -128,15 +104,8 @@ func UpdatePost(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, err)
 		return
 	}
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	if err = postUseCase.Update(userId, postId, post); err != nil {
+	if err = c.postUseCase.Update(userId, postId, post); err != nil {
 		var epv *errorType.ErrorPostValidation
 		if errors.As(err, &epv) {
 			response.Error(w, http.StatusBadRequest, epv.Err)
@@ -154,7 +123,7 @@ func UpdatePost(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func DeletePost(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) DeletePost(w http.ResponseWriter, r *http.Request) {
 	userId, err := authentication.ExtractUserId(r)
 	if err != nil {
 		response.Error(w, http.StatusUnauthorized, err)
@@ -166,15 +135,8 @@ func DeletePost(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, err)
 		return
 	}
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	if err = postUseCase.Delete(postId, userId); err != nil {
+	if err = c.postUseCase.Delete(postId, userId); err != nil {
 		if errors.Is(err, usecase.ErrAccessDenied) {
 			response.Error(w, http.StatusForbidden, err)
 			return
@@ -187,27 +149,20 @@ func DeletePost(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func GetUserPosts(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) GetUserPosts(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
-	db, err := database.Connect()
+	posts, err := c.postUseCase.GetUserPosts(userId)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
-	}
-	defer db.Close()
-
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	posts, err := postUseCase.GetUserPosts(userId)
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
 	}
 
 	response.JSON(w, http.StatusOK, posts)
 }
 
-func LikePost(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) LikePost(w http.ResponseWriter, r *http.Request) {
 	//userId, err := authentication.ExtractUserId(r)
 	//if err != nil {
 	//	responses.Error(w, http.StatusUnauthorized, err)
@@ -219,16 +174,8 @@ func LikePost(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, err)
 		return
 	}
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	err = postUseCase.LikePost(postId)
-	if err != nil {
+	if err = c.postUseCase.LikePost(postId); err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -236,23 +183,15 @@ func LikePost(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func UnlikePost(w http.ResponseWriter, r *http.Request) {
+func (c *PostController) UnlikePost(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	postId, err := strconv.ParseUint(params["postId"], 10, 64)
 	if err != nil {
 		response.Error(w, http.StatusBadRequest, err)
 		return
 	}
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	postUseCase := usecase.NewPostUseCase(repository.NewPostRepository(db))
-	err = postUseCase.UnLikePost(postId)
-	if err != nil {
+	if err = c.postUseCase.UnLikePost(postId); err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/internal/controller/post_controller_test.go
+++ b/internal/controller/post_controller_test.go
@@ -1,0 +1,308 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edigar/socialnets-api/internal/entity"
+	"github.com/edigar/socialnets-api/internal/error_type"
+	"github.com/edigar/socialnets-api/internal/usecase"
+)
+
+func TestPostPost(t *testing.T) {
+	validBody := `{"title":"Title","content":"Content"}`
+
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		c.PostPost(rec, newRequest(http.MethodPost, validBody))
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 400 for an invalid JSON body", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		c.PostPost(rec, withAuth(newRequest(http.MethodPost, `{`), testUserID))
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 400 for a validation error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{createPostFn: func(*entity.Post) error {
+			return errorType.NewErrorPostValidation("title is required")
+		}})
+		rec := httptest.NewRecorder()
+		c.PostPost(rec, withAuth(newRequest(http.MethodPost, validBody), testUserID))
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 201 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{createPostFn: func(*entity.Post) error { return nil }})
+		rec := httptest.NewRecorder()
+		c.PostPost(rec, withAuth(newRequest(http.MethodPost, validBody), testUserID))
+		assertStatus(t, rec.Code, http.StatusCreated)
+	})
+
+	t.Run("Should return 500 on unexpected error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{createPostFn: func(*entity.Post) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		c.PostPost(rec, withAuth(newRequest(http.MethodPost, validBody), testUserID))
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestGetPosts(t *testing.T) {
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		c.GetPosts(rec, newRequest(http.MethodGet, ""))
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 200 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{getByUserFn: func(string) ([]entity.Post, error) {
+			return []entity.Post{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		c.GetPosts(rec, withAuth(newRequest(http.MethodGet, ""), testUserID))
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{getByUserFn: func(string) ([]entity.Post, error) {
+			return nil, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		c.GetPosts(rec, withAuth(newRequest(http.MethodGet, ""), testUserID))
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestGetPost(t *testing.T) {
+	t.Run("Should return 400 for a non-numeric post id", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"postId": "abc"})
+		c.GetPost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 200 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{getByIdFn: func(uint64) (entity.Post, error) {
+			return entity.Post{Id: 1}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"postId": "1"})
+		c.GetPost(rec, req)
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{getByIdFn: func(uint64) (entity.Post, error) {
+			return entity.Post{}, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"postId": "1"})
+		c.GetPost(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestUpdatePost(t *testing.T) {
+	validBody := `{"title":"Title","content":"Content"}`
+
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"postId": "1"})
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 400 for a non-numeric post id", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"postId": "abc"})
+		req = withAuth(req, testUserID)
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 400 for an invalid JSON body", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, `{`), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 400 for a validation error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{updateFn: func(string, uint64, entity.Post) error {
+			return errorType.NewErrorPostValidation("invalid")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 403 when access is denied", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{updateFn: func(string, uint64, entity.Post) error {
+			return usecase.ErrAccessDenied
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{updateFn: func(string, uint64, entity.Post) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on unexpected error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{updateFn: func(string, uint64, entity.Post) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.UpdatePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestDeletePost(t *testing.T) {
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"postId": "1"})
+		c.DeletePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 400 for a non-numeric post id", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"postId": "abc"})
+		req = withAuth(req, testUserID)
+		c.DeletePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 403 when access is denied", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{deleteFn: func(uint64, string) error {
+			return usecase.ErrAccessDenied
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.DeletePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{deleteFn: func(uint64, string) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.DeletePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on unexpected error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{deleteFn: func(uint64, string) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"postId": "1"})
+		req = withAuth(req, testUserID)
+		c.DeletePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestGetUserPosts(t *testing.T) {
+	t.Run("Should return 200 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{getUserPostsFn: func(string) ([]entity.Post, error) {
+			return []entity.Post{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetUserPosts(rec, req)
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{getUserPostsFn: func(string) ([]entity.Post, error) {
+			return nil, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetUserPosts(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestLikePost(t *testing.T) {
+	t.Run("Should return 400 for a non-numeric post id", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"postId": "abc"})
+		c.LikePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{likePostFn: func(uint64) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"postId": "1"})
+		c.LikePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{likePostFn: func(uint64) error { return errors.New("db down") }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"postId": "1"})
+		c.LikePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestUnlikePost(t *testing.T) {
+	t.Run("Should return 400 for a non-numeric post id", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"postId": "abc"})
+		c.UnlikePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{unLikePostFn: func(uint64) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"postId": "1"})
+		c.UnlikePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewPostController(&mockPostUseCase{unLikePostFn: func(uint64) error { return errors.New("db down") }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"postId": "1"})
+		c.UnlikePost(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}

--- a/internal/controller/usecase_mock_test.go
+++ b/internal/controller/usecase_mock_test.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/edigar/socialnets-api/internal/authentication"
+	"github.com/edigar/socialnets-api/internal/dto"
+	"github.com/edigar/socialnets-api/internal/entity"
+	"github.com/gorilla/mux"
+)
+
+// mockUserUseCase implements controller.UserUseCase with configurable behavior per test.
+type mockUserUseCase struct {
+	loginFn           func(email string, password string) (string, error)
+	registerFn        func(user *entity.User) error
+	getByIdFn         func(id string) (entity.User, error)
+	getByNameOrNickFn func(nameOrNick string) ([]entity.User, error)
+	updateFn          func(userId string, user entity.User) error
+	deleteFn          func(userId string) error
+	followFn          func(userId string, follower string) error
+	unfollowFn        func(userId string, follower string) error
+	getFollowersFn    func(userId string) ([]entity.User, error)
+	getFollowingFn    func(userId string) ([]entity.User, error)
+	updatePasswordFn  func(userId string, password dto.Password) error
+}
+
+func (m *mockUserUseCase) Login(email string, password string) (string, error) {
+	return m.loginFn(email, password)
+}
+func (m *mockUserUseCase) Register(user *entity.User) error       { return m.registerFn(user) }
+func (m *mockUserUseCase) GetById(id string) (entity.User, error) { return m.getByIdFn(id) }
+func (m *mockUserUseCase) GetByNameOrNick(nameOrNick string) ([]entity.User, error) {
+	return m.getByNameOrNickFn(nameOrNick)
+}
+func (m *mockUserUseCase) Update(userId string, user entity.User) error {
+	return m.updateFn(userId, user)
+}
+func (m *mockUserUseCase) Delete(userId string) error { return m.deleteFn(userId) }
+func (m *mockUserUseCase) Follow(userId string, follower string) error {
+	return m.followFn(userId, follower)
+}
+func (m *mockUserUseCase) Unfollow(userId string, follower string) error {
+	return m.unfollowFn(userId, follower)
+}
+func (m *mockUserUseCase) GetFollowers(userId string) ([]entity.User, error) {
+	return m.getFollowersFn(userId)
+}
+func (m *mockUserUseCase) GetFollowing(userId string) ([]entity.User, error) {
+	return m.getFollowingFn(userId)
+}
+func (m *mockUserUseCase) UpdatePassword(userId string, password dto.Password) error {
+	return m.updatePasswordFn(userId, password)
+}
+
+// mockPostUseCase implements controller.PostUseCase with configurable behavior per test.
+type mockPostUseCase struct {
+	createPostFn   func(post *entity.Post) error
+	getByUserFn    func(userId string) ([]entity.Post, error)
+	getByIdFn      func(postId uint64) (entity.Post, error)
+	updateFn       func(authorId string, postId uint64, post entity.Post) error
+	deleteFn       func(postId uint64, authorId string) error
+	getUserPostsFn func(userId string) ([]entity.Post, error)
+	likePostFn     func(postId uint64) error
+	unLikePostFn   func(postId uint64) error
+}
+
+func (m *mockPostUseCase) CreatePost(post *entity.Post) error { return m.createPostFn(post) }
+func (m *mockPostUseCase) GetByUser(userId string) ([]entity.Post, error) {
+	return m.getByUserFn(userId)
+}
+func (m *mockPostUseCase) GetById(postId uint64) (entity.Post, error) { return m.getByIdFn(postId) }
+func (m *mockPostUseCase) Update(authorId string, postId uint64, post entity.Post) error {
+	return m.updateFn(authorId, postId, post)
+}
+func (m *mockPostUseCase) Delete(postId uint64, authorId string) error {
+	return m.deleteFn(postId, authorId)
+}
+func (m *mockPostUseCase) GetUserPosts(userId string) ([]entity.Post, error) {
+	return m.getUserPostsFn(userId)
+}
+func (m *mockPostUseCase) LikePost(postId uint64) error   { return m.likePostFn(postId) }
+func (m *mockPostUseCase) UnLikePost(postId uint64) error { return m.unLikePostFn(postId) }
+
+// --- request helpers ---
+
+func newRequest(method, body string) *http.Request {
+	if body == "" {
+		return httptest.NewRequest(method, "/", nil)
+	}
+	return httptest.NewRequest(method, "/", strings.NewReader(body))
+}
+
+// withAuth attaches a valid Bearer token whose userId claim is the given id.
+func withAuth(r *http.Request, userId string) *http.Request {
+	token, _ := authentication.CreateToken(userId)
+	r.Header.Set("Authorization", "Bearer "+token)
+	return r
+}
+
+func withVars(r *http.Request, vars map[string]string) *http.Request {
+	return mux.SetURLVars(r, vars)
+}

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/edigar/socialnets-api/internal/authentication"
-	"github.com/edigar/socialnets-api/internal/database"
 	"github.com/edigar/socialnets-api/internal/dto"
 	"github.com/edigar/socialnets-api/internal/entity"
 	"github.com/edigar/socialnets-api/internal/error_type"
-	"github.com/edigar/socialnets-api/internal/repository"
 	"github.com/edigar/socialnets-api/internal/response"
 	"github.com/edigar/socialnets-api/internal/usecase"
 	"github.com/gorilla/mux"
@@ -19,7 +17,7 @@ import (
 	"strings"
 )
 
-func PostUser(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) PostUser(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		response.Error(w, http.StatusUnprocessableEntity, err)
@@ -32,15 +30,7 @@ func PostUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	if err = userUseCase.Register(&user); err != nil {
+	if err = c.userUseCase.Register(&user); err != nil {
 		var uve *errorType.ErrorUserValidation
 		if errors.As(err, &uve) {
 			response.Error(w, http.StatusBadRequest, uve.Err)
@@ -54,17 +44,10 @@ func PostUser(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusCreated, user)
 }
 
-func GetUsers(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) GetUsers(w http.ResponseWriter, r *http.Request) {
 	nameOrNick := strings.ToLower(r.URL.Query().Get("search"))
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
 
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	users, err := userUseCase.GetByNameOrNick(nameOrNick)
+	users, err := c.userUseCase.GetByNameOrNick(nameOrNick)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
@@ -73,20 +56,11 @@ func GetUsers(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusOK, users)
 }
 
-func GetUser(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) GetUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-
-	user, err := userUseCase.GetById(userId)
+	user, err := c.userUseCase.GetById(userId)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
@@ -100,7 +74,7 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusOK, user)
 }
 
-func UpdateUser(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
@@ -126,15 +100,7 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	if err = userUseCase.Update(userId, user); err != nil {
+	if err = c.userUseCase.Update(userId, user); err != nil {
 		var uve *errorType.ErrorUserValidation
 		if errors.As(err, &uve) {
 			response.Error(w, http.StatusBadRequest, uve.Err)
@@ -148,7 +114,7 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func DeleteUser(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
@@ -162,22 +128,15 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	db, err := database.Connect()
-	if err != nil {
+	if err = c.userUseCase.Delete(userId); err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	if err = userUseCase.Delete(userId); err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
 	}
 
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func Follow(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) Follow(w http.ResponseWriter, r *http.Request) {
 	follower, err := authentication.ExtractUserId(r)
 	if err != nil {
 		response.Error(w, http.StatusUnauthorized, err)
@@ -187,15 +146,7 @@ func Follow(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	if err = userUseCase.Follow(userId, follower); err != nil {
+	if err = c.userUseCase.Follow(userId, follower); err != nil {
 		if errors.Is(err, usecase.ErrOperationDenied) {
 			response.Error(w, http.StatusForbidden, err)
 			return
@@ -208,7 +159,7 @@ func Follow(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func Unfollow(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) Unfollow(w http.ResponseWriter, r *http.Request) {
 	follower, err := authentication.ExtractUserId(r)
 	if err != nil {
 		response.Error(w, http.StatusUnauthorized, err)
@@ -218,15 +169,7 @@ func Unfollow(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	if err = userUseCase.Unfollow(userId, follower); err != nil {
+	if err = c.userUseCase.Unfollow(userId, follower); err != nil {
 		if errors.Is(err, usecase.ErrOperationDenied) {
 			response.Error(w, http.StatusForbidden, err)
 			return
@@ -239,19 +182,11 @@ func Unfollow(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusNoContent, nil)
 }
 
-func GetFollowers(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) GetFollowers(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	followers, err := userUseCase.GetFollowers(userId)
+	followers, err := c.userUseCase.GetFollowers(userId)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
@@ -260,19 +195,11 @@ func GetFollowers(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusOK, followers)
 }
 
-func GetFollowing(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) GetFollowing(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
-	defer db.Close()
-
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	following, err := userUseCase.GetFollowing(userId)
+	following, err := c.userUseCase.GetFollowing(userId)
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, err)
 		return
@@ -281,7 +208,7 @@ func GetFollowing(w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, http.StatusOK, following)
 }
 
-func UpdatePassword(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) UpdatePassword(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	userId := fmt.Sprintf("%s", params["userId"])
 
@@ -304,17 +231,10 @@ func UpdatePassword(w http.ResponseWriter, r *http.Request) {
 	var password dto.Password
 	if err = json.Unmarshal(body, &password); err != nil {
 		response.Error(w, http.StatusBadRequest, err)
-	}
-
-	db, err := database.Connect()
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
 		return
 	}
-	defer db.Close()
 
-	userUseCase := usecase.NewUserUseCase(repository.NewUserRepository(db))
-	if err = userUseCase.UpdatePassword(userId, password); err != nil {
+	if err = c.userUseCase.UpdatePassword(userId, password); err != nil {
 		if errors.Is(err, usecase.ErrWrongPassword) {
 			response.Error(w, http.StatusUnauthorized, err)
 			return

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -1,0 +1,447 @@
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edigar/socialnets-api/internal/dto"
+	"github.com/edigar/socialnets-api/internal/entity"
+	"github.com/edigar/socialnets-api/internal/error_type"
+	"github.com/edigar/socialnets-api/internal/usecase"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	testUserID  = "eedf21bf-dde8-4c85-b50b-89a1cba87c2e"
+	otherUserID = "11111111-1111-1111-1111-111111111111"
+)
+
+func assertStatus(t *testing.T, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("expected status %d, got %d", want, got)
+	}
+}
+
+func TestPostUser(t *testing.T) {
+	validBody := `{"name":"User Name","nick":"user","email":"user@mail.com","password":"123"}`
+
+	t.Run("Should return 201 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{registerFn: func(*entity.User) error { return nil }})
+		rec := httptest.NewRecorder()
+		c.PostUser(rec, newRequest(http.MethodPost, validBody))
+		assertStatus(t, rec.Code, http.StatusCreated)
+	})
+
+	t.Run("Should return 400 for an invalid JSON body", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		c.PostUser(rec, newRequest(http.MethodPost, `{`))
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 400 for a validation error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{registerFn: func(*entity.User) error {
+			return errorType.NewErrorUserValidation("name is required")
+		}})
+		rec := httptest.NewRecorder()
+		c.PostUser(rec, newRequest(http.MethodPost, validBody))
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 500 for an unexpected error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{registerFn: func(*entity.User) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		c.PostUser(rec, newRequest(http.MethodPost, validBody))
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestLogin(t *testing.T) {
+	body := `{"email":"user@mail.com","password":"123"}`
+
+	t.Run("Should return 200 and a token on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{loginFn: func(string, string) (string, error) {
+			return testUserID, nil
+		}})
+		rec := httptest.NewRecorder()
+		c.Login(rec, newRequest(http.MethodPost, body))
+		assertStatus(t, rec.Code, http.StatusOK)
+
+		var decoded struct {
+			Id    string `json:"id"`
+			Token string `json:"token"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&decoded); err != nil {
+			t.Fatalf("response should be valid JSON: %v", err)
+		}
+		if decoded.Id != testUserID || decoded.Token == "" {
+			t.Errorf("Login should return the user id and a non-empty token. Got: %+v", decoded)
+		}
+	})
+
+	t.Run("Should return 401 for wrong credentials", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{loginFn: func(string, string) (string, error) {
+			return "", bcrypt.ErrMismatchedHashAndPassword
+		}})
+		rec := httptest.NewRecorder()
+		c.Login(rec, newRequest(http.MethodPost, body))
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 500 for an unexpected error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{loginFn: func(string, string) (string, error) {
+			return "", errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		c.Login(rec, newRequest(http.MethodPost, body))
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+
+	t.Run("Should return 400 for an invalid JSON body", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		c.Login(rec, newRequest(http.MethodPost, `{`))
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+}
+
+func TestGetUsers(t *testing.T) {
+	t.Run("Should return 200 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getByNameOrNickFn: func(string) ([]entity.User, error) {
+			return []entity.User{{Id: testUserID}}, nil
+		}})
+		rec := httptest.NewRecorder()
+		c.GetUsers(rec, newRequest(http.MethodGet, ""))
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getByNameOrNickFn: func(string) ([]entity.User, error) {
+			return nil, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		c.GetUsers(rec, newRequest(http.MethodGet, ""))
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestGetUser(t *testing.T) {
+	t.Run("Should return 200 when the user exists", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getByIdFn: func(string) (entity.User, error) {
+			return entity.User{Id: testUserID, Name: "User"}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("Should return 404 when the user is empty", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getByIdFn: func(string) (entity.User, error) {
+			return entity.User{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusNotFound)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getByIdFn: func(string) (entity.User, error) {
+			return entity.User{}, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestUpdateUser(t *testing.T) {
+	validBody := `{"name":"New Name","nick":"new","email":"new@mail.com"}`
+
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"userId": testUserID})
+		c.UpdateUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 403 when token user differs from path user", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"userId": otherUserID})
+		req = withAuth(req, testUserID)
+		c.UpdateUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 400 for an invalid JSON body", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, `{`), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdateUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 400 for a validation error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updateFn: func(string, entity.User) error {
+			return errorType.NewErrorUserValidation("invalid")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdateUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updateFn: func(string, entity.User) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdateUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on unexpected error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updateFn: func(string, entity.User) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPut, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdateUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestDeleteUser(t *testing.T) {
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"userId": testUserID})
+		c.DeleteUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 403 when token user differs from path user", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"userId": otherUserID})
+		req = withAuth(req, testUserID)
+		c.DeleteUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{deleteFn: func(string) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.DeleteUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{deleteFn: func(string) error { return errors.New("db down") }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodDelete, ""), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.DeleteUser(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestFollow(t *testing.T) {
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": otherUserID})
+		c.Follow(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 403 when the operation is denied", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{followFn: func(string, string) error {
+			return usecase.ErrOperationDenied
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.Follow(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{followFn: func(string, string) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": otherUserID})
+		req = withAuth(req, testUserID)
+		c.Follow(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{followFn: func(string, string) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": otherUserID})
+		req = withAuth(req, testUserID)
+		c.Follow(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestUnfollow(t *testing.T) {
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": otherUserID})
+		c.Unfollow(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 403 when the operation is denied", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{unfollowFn: func(string, string) error {
+			return usecase.ErrOperationDenied
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.Unfollow(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{unfollowFn: func(string, string) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, ""), map[string]string{"userId": otherUserID})
+		req = withAuth(req, testUserID)
+		c.Unfollow(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+}
+
+func TestGetFollowersAndFollowing(t *testing.T) {
+	t.Run("GetFollowers should return 200 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getFollowersFn: func(string) ([]entity.User, error) {
+			return []entity.User{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetFollowers(rec, req)
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("GetFollowers should return 500 on error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getFollowersFn: func(string) ([]entity.User, error) {
+			return nil, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetFollowers(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+
+	t.Run("GetFollowing should return 200 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getFollowingFn: func(string) ([]entity.User, error) {
+			return []entity.User{}, nil
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetFollowing(rec, req)
+		assertStatus(t, rec.Code, http.StatusOK)
+	})
+
+	t.Run("GetFollowing should return 500 on error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{getFollowingFn: func(string) ([]entity.User, error) {
+			return nil, errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodGet, ""), map[string]string{"userId": testUserID})
+		c.GetFollowing(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}
+
+func TestUpdatePassword(t *testing.T) {
+	validBody := `{"current":"123","new":"456"}`
+
+	t.Run("Should return 401 without a token", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, validBody), map[string]string{"userId": testUserID})
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 403 when token user differs from path user", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, validBody), map[string]string{"userId": otherUserID})
+		req = withAuth(req, testUserID)
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusForbidden)
+	})
+
+	t.Run("Should return 400 for an invalid JSON body", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, `{`), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 401 for a wrong current password", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updatePasswordFn: func(string, dto.Password) error {
+			return usecase.ErrWrongPassword
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Should return 400 when the new password is too long", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updatePasswordFn: func(string, dto.Password) error {
+			return bcrypt.ErrPasswordTooLong
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusBadRequest)
+	})
+
+	t.Run("Should return 204 on success", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updatePasswordFn: func(string, dto.Password) error { return nil }})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusNoContent)
+	})
+
+	t.Run("Should return 500 on unexpected error", func(t *testing.T) {
+		c := NewUserController(&mockUserUseCase{updatePasswordFn: func(string, dto.Password) error {
+			return errors.New("db down")
+		}})
+		rec := httptest.NewRecorder()
+		req := withVars(newRequest(http.MethodPost, validBody), map[string]string{"userId": testUserID})
+		req = withAuth(req, testUserID)
+		c.UpdatePassword(rec, req)
+		assertStatus(t, rec.Code, http.StatusInternalServerError)
+	})
+}

--- a/internal/error_type/error_type_test.go
+++ b/internal/error_type/error_type_test.go
@@ -1,0 +1,32 @@
+package errorType
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorUserValidation(t *testing.T) {
+	err := NewErrorUserValidation("name is required")
+
+	if err.Error() != "name is required" {
+		t.Errorf("Error() should return the message, got %q", err.Error())
+	}
+
+	var target *ErrorUserValidation
+	if !errors.As(err, &target) {
+		t.Errorf("errors.As should detect *ErrorUserValidation")
+	}
+}
+
+func TestErrorPostValidation(t *testing.T) {
+	err := NewErrorPostValidation("title is required")
+
+	if err.Error() != "title is required" {
+		t.Errorf("Error() should return the message, got %q", err.Error())
+	}
+
+	var target *ErrorPostValidation
+	if !errors.As(err, &target) {
+		t.Errorf("errors.As should detect *ErrorPostValidation")
+	}
+}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edigar/socialnets-api/internal/authentication"
+)
+
+func TestAuthenticate(t *testing.T) {
+	t.Run("Should call the next handler for a valid token", func(t *testing.T) {
+		called := false
+		next := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}
+
+		token, err := authentication.CreateToken("eedf21bf-dde8-4c85-b50b-89a1cba87c2e")
+		if err != nil {
+			t.Fatalf("CreateToken should not return an error: %v", err)
+		}
+
+		request, _ := http.NewRequest(http.MethodGet, "/", nil)
+		request.Header.Set("Authorization", "Bearer "+token)
+		recorder := httptest.NewRecorder()
+
+		Authenticate(next)(recorder, request)
+
+		if !called {
+			t.Errorf("Authenticate should call the next handler for a valid token")
+		}
+		if recorder.Code != http.StatusOK {
+			t.Errorf("Authenticate should respond with status %d for a valid token. Got: %d", http.StatusOK, recorder.Code)
+		}
+	})
+
+	t.Run("Should respond 401 and not call next for an invalid token", func(t *testing.T) {
+		called := false
+		next := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		request, _ := http.NewRequest(http.MethodGet, "/", nil)
+		request.Header.Set("Authorization", "Bearer invalid-token")
+		recorder := httptest.NewRecorder()
+
+		Authenticate(next)(recorder, request)
+
+		if called {
+			t.Errorf("Authenticate should not call the next handler for an invalid token")
+		}
+		if recorder.Code != http.StatusUnauthorized {
+			t.Errorf("Authenticate should respond with status %d for an invalid token. Got: %d", http.StatusUnauthorized, recorder.Code)
+		}
+	})
+
+	t.Run("Should respond 401 and not call next when the Authorization header is missing", func(t *testing.T) {
+		called := false
+		next := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		request, _ := http.NewRequest(http.MethodGet, "/", nil)
+		recorder := httptest.NewRecorder()
+
+		Authenticate(next)(recorder, request)
+
+		if called {
+			t.Errorf("Authenticate should not call the next handler when the Authorization header is missing")
+		}
+		if recorder.Code != http.StatusUnauthorized {
+			t.Errorf("Authenticate should respond with status %d when the Authorization header is missing. Got: %d", http.StatusUnauthorized, recorder.Code)
+		}
+	})
+}
+
+func TestLogger(t *testing.T) {
+	t.Run("Should call the next handler", func(t *testing.T) {
+		called := false
+		next := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		request, _ := http.NewRequest(http.MethodGet, "/", nil)
+		recorder := httptest.NewRecorder()
+
+		Logger(next)(recorder, request)
+
+		if !called {
+			t.Errorf("Logger should call the next handler")
+		}
+	})
+}

--- a/internal/response/response_test.go
+++ b/internal/response/response_test.go
@@ -1,0 +1,72 @@
+package response
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJSON(t *testing.T) {
+	t.Run("Should write content-type, status code and JSON body", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		data := struct {
+			Message string `json:"message"`
+		}{Message: "hello"}
+
+		JSON(recorder, http.StatusCreated, data)
+
+		if recorder.Code != http.StatusCreated {
+			t.Errorf("JSON should write status %d. Got: %d", http.StatusCreated, recorder.Code)
+		}
+		if contentType := recorder.Header().Get("Content-Type"); contentType != "application/json" {
+			t.Errorf("JSON should set Content-Type to application/json. Got: %q", contentType)
+		}
+
+		var decoded struct {
+			Message string `json:"message"`
+		}
+		if err := json.NewDecoder(recorder.Body).Decode(&decoded); err != nil {
+			t.Fatalf("JSON body should be valid JSON: %v", err)
+		}
+		if decoded.Message != data.Message {
+			t.Errorf("JSON should encode the given data. Expected message %q. Got: %q", data.Message, decoded.Message)
+		}
+	})
+
+	t.Run("Should not write a body when data is nil", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		JSON(recorder, http.StatusNoContent, nil)
+
+		if recorder.Code != http.StatusNoContent {
+			t.Errorf("JSON should write status %d. Got: %d", http.StatusNoContent, recorder.Code)
+		}
+		if recorder.Body.Len() != 0 {
+			t.Errorf("JSON should not write a body when data is nil. Got: %q", recorder.Body.String())
+		}
+	})
+}
+
+func TestError(t *testing.T) {
+	t.Run("Should write an error body with the given status code", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		Error(recorder, http.StatusBadRequest, errors.New("boom"))
+
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("Error should write status %d. Got: %d", http.StatusBadRequest, recorder.Code)
+		}
+
+		var decoded struct {
+			Error string `json:"error"`
+		}
+		if err := json.NewDecoder(recorder.Body).Decode(&decoded); err != nil {
+			t.Fatalf("Error body should be valid JSON: %v", err)
+		}
+		if decoded.Error != "boom" {
+			t.Errorf("Error should render the error message. Expected %q. Got: %q", "boom", decoded.Error)
+		}
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,11 +1,12 @@
 package router
 
 import (
+	"database/sql"
 	"github.com/edigar/socialnets-api/internal/router/routes"
 	"github.com/gorilla/mux"
 )
 
-func Generate() *mux.Router {
+func Generate(db *sql.DB) *mux.Router {
 	r := mux.NewRouter()
-	return routes.Setup(r)
+	return routes.Setup(r, db)
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,59 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	// nil DB is safe: the repository/usecase/controller constructors only store
+	// the handle, and none of the routes exercised below reach a DB query.
+	r := Generate(nil)
+
+	t.Run("Should respond 200 on the public health route", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET /health should return 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Should respond 401 on protected routes without a token", func(t *testing.T) {
+		scenarios := []struct {
+			method string
+			path   string
+		}{
+			{http.MethodGet, "/api/user"},
+			{http.MethodPost, "/api/post"},
+		}
+
+		for _, scenario := range scenarios {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(scenario.method, scenario.path, nil)
+			r.ServeHTTP(rec, req)
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("%s %s without a token should return 401, got %d", scenario.method, scenario.path, rec.Code)
+			}
+		}
+	})
+
+	t.Run("Should respond 404 on an unknown path", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/does-not-exist", nil)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("GET /does-not-exist should return 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Should respond 405 for a wrong method on an existing path", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodDelete, "/health", nil)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("DELETE /health should return 405, got %d", rec.Code)
+		}
+	})
+}

--- a/internal/router/routes/login.go
+++ b/internal/router/routes/login.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 )
 
-var loginRoute = Route{
-	URI:                    "/api/login",
-	Method:                 http.MethodPost,
-	Function:               controller.Login,
-	AuthenticationRequired: false,
+func loginRoute(c *controller.UserController) Route {
+	return Route{
+		URI:                    "/api/login",
+		Method:                 http.MethodPost,
+		Function:               c.Login,
+		AuthenticationRequired: false,
+	}
 }

--- a/internal/router/routes/post.go
+++ b/internal/router/routes/post.go
@@ -5,53 +5,55 @@ import (
 	"net/http"
 )
 
-var postRoutes = []Route{
-	{
-		URI:                    "/api/post",
-		Method:                 http.MethodPost,
-		Function:               controller.PostPost,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/post",
-		Method:                 http.MethodGet,
-		Function:               controller.GetPosts,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/post/{postId}",
-		Method:                 http.MethodGet,
-		Function:               controller.GetPost,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/post/{postId}",
-		Method:                 http.MethodPut,
-		Function:               controller.UpdatePost,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/post/{postId}",
-		Method:                 http.MethodDelete,
-		Function:               controller.DeletePost,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}/posts",
-		Method:                 http.MethodGet,
-		Function:               controller.GetUserPosts,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/post/{postId}/like",
-		Method:                 http.MethodPost,
-		Function:               controller.LikePost,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/post/{postId}/unlike",
-		Method:                 http.MethodPost,
-		Function:               controller.UnlikePost,
-		AuthenticationRequired: true,
-	},
+func postRoutes(c *controller.PostController) []Route {
+	return []Route{
+		{
+			URI:                    "/api/post",
+			Method:                 http.MethodPost,
+			Function:               c.PostPost,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/post",
+			Method:                 http.MethodGet,
+			Function:               c.GetPosts,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/post/{postId}",
+			Method:                 http.MethodGet,
+			Function:               c.GetPost,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/post/{postId}",
+			Method:                 http.MethodPut,
+			Function:               c.UpdatePost,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/post/{postId}",
+			Method:                 http.MethodDelete,
+			Function:               c.DeletePost,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}/posts",
+			Method:                 http.MethodGet,
+			Function:               c.GetUserPosts,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/post/{postId}/like",
+			Method:                 http.MethodPost,
+			Function:               c.LikePost,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/post/{postId}/unlike",
+			Method:                 http.MethodPost,
+			Function:               c.UnlikePost,
+			AuthenticationRequired: true,
+		},
+	}
 }

--- a/internal/router/routes/routes.go
+++ b/internal/router/routes/routes.go
@@ -1,7 +1,11 @@
 package routes
 
 import (
+	"database/sql"
+	"github.com/edigar/socialnets-api/internal/controller"
 	"github.com/edigar/socialnets-api/internal/middleware"
+	"github.com/edigar/socialnets-api/internal/repository"
+	"github.com/edigar/socialnets-api/internal/usecase"
 	"github.com/gorilla/mux"
 	"net/http"
 )
@@ -13,10 +17,13 @@ type Route struct {
 	AuthenticationRequired bool
 }
 
-func Setup(r *mux.Router) *mux.Router {
-	routes := userRoutes
-	routes = append(routes, loginRoute)
-	routes = append(routes, postRoutes...)
+func Setup(r *mux.Router, db *sql.DB) *mux.Router {
+	userController := controller.NewUserController(usecase.NewUserUseCase(repository.NewUserRepository(db)))
+	postController := controller.NewPostController(usecase.NewPostUseCase(repository.NewPostRepository(db)))
+
+	routes := userRoutes(userController)
+	routes = append(routes, loginRoute(userController))
+	routes = append(routes, postRoutes(postController)...)
 	routes = append(routes, healthRoute)
 
 	for _, route := range routes {

--- a/internal/router/routes/user.go
+++ b/internal/router/routes/user.go
@@ -5,65 +5,67 @@ import (
 	"net/http"
 )
 
-var userRoutes = []Route{
-	{
-		URI:                    "/api/user",
-		Method:                 http.MethodPost,
-		Function:               controller.PostUser,
-		AuthenticationRequired: false,
-	},
-	{
-		URI:                    "/api/user",
-		Method:                 http.MethodGet,
-		Function:               controller.GetUsers,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}",
-		Method:                 http.MethodGet,
-		Function:               controller.GetUser,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}",
-		Method:                 http.MethodPut,
-		Function:               controller.UpdateUser,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}",
-		Method:                 http.MethodDelete,
-		Function:               controller.DeleteUser,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}/follow",
-		Method:                 http.MethodPost,
-		Function:               controller.Follow,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}/unfollow",
-		Method:                 http.MethodPost,
-		Function:               controller.Unfollow,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}/followers",
-		Method:                 http.MethodGet,
-		Function:               controller.GetFollowers,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}/following",
-		Method:                 http.MethodGet,
-		Function:               controller.GetFollowing,
-		AuthenticationRequired: true,
-	},
-	{
-		URI:                    "/api/user/{userId}/update-password",
-		Method:                 http.MethodPost,
-		Function:               controller.UpdatePassword,
-		AuthenticationRequired: true,
-	},
+func userRoutes(c *controller.UserController) []Route {
+	return []Route{
+		{
+			URI:                    "/api/user",
+			Method:                 http.MethodPost,
+			Function:               c.PostUser,
+			AuthenticationRequired: false,
+		},
+		{
+			URI:                    "/api/user",
+			Method:                 http.MethodGet,
+			Function:               c.GetUsers,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}",
+			Method:                 http.MethodGet,
+			Function:               c.GetUser,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}",
+			Method:                 http.MethodPut,
+			Function:               c.UpdateUser,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}",
+			Method:                 http.MethodDelete,
+			Function:               c.DeleteUser,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}/follow",
+			Method:                 http.MethodPost,
+			Function:               c.Follow,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}/unfollow",
+			Method:                 http.MethodPost,
+			Function:               c.Unfollow,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}/followers",
+			Method:                 http.MethodGet,
+			Function:               c.GetFollowers,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}/following",
+			Method:                 http.MethodGet,
+			Function:               c.GetFollowing,
+			AuthenticationRequired: true,
+		},
+		{
+			URI:                    "/api/user/{userId}/update-password",
+			Method:                 http.MethodPost,
+			Function:               c.UpdatePassword,
+			AuthenticationRequired: true,
+		},
+	}
 }


### PR DESCRIPTION
## Description
Substantially improves the project's test coverage and restores a meaningful coverage gate. It builds on #77 (the `x/crypto`/Go 1.25 bump), which had to temporarily lower the CI gate to 15% because Go 1.25 changed how coverage is measured (packages without tests now count as 0% in the module total).

This PR adds tests to the packages that were at 0%, refactors the controller layer so it can be unit-tested, fixes a few latent handler bugs found along the way, and raises the coverage gate back to a meaningful 50%. Module-wide coverage goes from ~18.7% to 58.9%.

## Checklist
- [x] Tests has been changed.
- [x] All tests pass.
- [ ] Documentation has been updated.
- [x] Code follows style guidelines.
- [x] All merge conflicts have been resolved.
- [x] The pull request is targeted to the correct branch.

## Related Issue
Builds on #77. No tracking issue.

## Proposed Changes
Grouped by the 4 commits in this branch:

- [x] **test: auth middleware, JWT security gaps and HTTP response helpers**
  - `middleware`: `Authenticate` lets valid tokens through and returns 401 (without calling next) for invalid/missing tokens; `Logger` passes through.
  - `authentication`: reject non-HMAC signing methods (algorithm-confusion defense), expired tokens and missing/malformed `Authorization` headers.
  - `response`: `JSON` sets content-type/status/body and omits the body when data is nil; `Error` renders `{"error":...}` with the given status.
- [x] **refactor(controller): inject usecases and connect the DB at startup**
  - Handlers became methods on `UserController`/`PostController` depending on usecase interfaces, wired in the routing layer; the DB is now connected once in `main()` and injected via `router.Generate`/`routes.Setup` instead of per request inside every handler.
  - Bug fixes (missing `return`/masked errors): `Login` and `UpdatePassword` no longer continue with an empty payload after an invalid body; `GetUserPosts` and `DeleteUser` no longer fall through to a success response after an error.
  - Full controller test suite with mocked usecases (httptest): success paths, auth/authorization (401/403), not-found (404) and error→status mapping.
- [x] **ci: raise coverage threshold from 15% to 50%**
  - The `Validate coverage` gate uses a numeric comparison (`bc`) and is set to 50%, now that honest coverage is ~58%.
- [x] **test: config loading, router wiring and validation error types**
  - `config`: `Load()` env→settings mapping, with port fallback to 8000.
  - `router`: smoke-tests the route table and auth middleware via `Generate(nil)` and httptest (health 200, protected routes 401, unknown path 404, 405).
  - `error_type`: validation error constructors and the `errors.As` contract.

## Tests Performed
Run on Go 1.25 (PowerShell):

go build ./...      # ok
go vet ./...        # ok
go test ./...       # all packages PASS
go test ./... -coverprofile=coverage
go tool cover -func=coverage | grep total
total: (statements) 58.9%


Per-package coverage after this PR: middleware 100%, router 100%, error_type 100%, controller 94.1%, authentication 92.9%, config 77.8%, response 83.3% (plus the pre-existing entity 94.7%, usecase 92.3%, crypt 100%). Only `database` and `repository` remain untested (they need a real DB or sqlmock).

## Additional Notes
- **Behavior change:** the database is now opened once at startup, so the app fails fast if the DB is unreachable (previously each request reconnected). Running locally now requires a reachable DB; `docker-compose` is unaffected.
- No application/production logic changed other than the controller DI wiring and the four handler bug fixes noted above. No new dependencies.